### PR TITLE
Upgrade jQuery to 3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@rails/ujs": "^6.0.2-2",
     "@rails/webpacker": "4.2.2",
     "bootstrap": "^4.4.1",
-    "jquery": "^3.4.1",
+    "jquery": "3.5.1",
     "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3876,10 +3876,10 @@ jest-worker@^25.1.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+jquery@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-base64@^2.1.8:
   version "2.5.2"


### PR DESCRIPTION
Upgrade to jQuery 3.5.1 for updated security fixes

[http://blog.jquery.com/2020/05/04/jquery-3-5-1-released-fixing-a-regression/](http://blog.jquery.com/2020/05/04/jquery-3-5-1-released-fixing-a-regression/)