### PR TITLE
Private prayer request

### DIFF
--- a/app/controllers/prayers_controller.rb
+++ b/app/controllers/prayers_controller.rb
@@ -3,7 +3,8 @@ class PrayersController < ApplicationController
   after_action :verify_authorized, only: [:edit, :update, :destroy]
 
   def index
-    @prayers = Prayer.all
+    # Only display non-private prayers
+    @prayers = Prayer.all.where(private: false)
   end
 
   def new
@@ -58,10 +59,10 @@ class PrayersController < ApplicationController
   def prayer_request
     if params[:type] == "single"
       # Order by random then call the first instance. This is to prevent missing ID in between (for eg, if we delete prayer with ID=3)
-      @prayer = Prayer.where(is_deleted: false).order("RANDOM()").first
+      @prayer = Prayer.where(is_deleted: false, private: false).order("RANDOM()").first
     elsif params[:type] == "multiple"
       # Currently multiple means 3 prayers
-      @prayers = Prayer.where(is_deleted: false).order("RANDOM()").sample(3)
+      @prayers = Prayer.where(is_deleted: false, private: false).order("RANDOM()").sample(3)
     end
   end
 

--- a/app/controllers/prayers_controller.rb
+++ b/app/controllers/prayers_controller.rb
@@ -106,7 +106,7 @@ class PrayersController < ApplicationController
 
   private
   def prayer_params
-    params.require(:prayer).permit(:request, :user_particulars, :is_deleted, :prayer_count, categories_attributes: [:name])
+    params.require(:prayer).permit(:request, :user_particulars, :is_deleted, :prayer_count, :private, categories_attributes: [:name])
   end
 
   def set_prayer

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,13 @@ class UsersController < ApplicationController
   end
 
   def show
+    # Only show all prayers if current_user is @user or current_user is friend with @user
+    if (current_user == @user) or current_user.friends_with?(@user)
+      @prayers = @user.prayers
+    else
+      # Only see prayers where private is not true
+      @prayers = @user.prayers.where.not(private: true)
+    end
   end
 
   def add_friends

--- a/app/views/prayers/edit.html.erb
+++ b/app/views/prayers/edit.html.erb
@@ -12,6 +12,13 @@
         <%= f.select :status, Prayer.statuses.keys.to_a %>
         <%= f.hidden_field :status, :name => 'curr_status' %>
       </div>
+      <div class="form-group">
+        <%= f.label :private, 'Make your prayer private?' %>
+        <%= f.check_box :private %>
+        <br/>
+        <span class="font-italic text-warning">A private prayer is one that only your friends can see!</span>
+        <br/>
+      </div>
       
       <%= f.submit 'Submit', class: 'btn btn-sm btn-primary' %>
     <% end %>

--- a/app/views/prayers/new.html.erb
+++ b/app/views/prayers/new.html.erb
@@ -28,6 +28,15 @@
             <option>Relationships</option>
          </select>
       </div>
+      <% if user_signed_in? %>
+        <div class="form-group">
+          <%= f.label :private, 'Make your prayer private?' %>
+          <%= f.check_box :private %>
+          <br/>
+          <span class="font-italic text-warning">A private prayer is one that only your friends can see!</span>
+          <br/>
+        </div>
+      <% end %>
       <%= f.submit 'Submit', class: 'btn btn-sm btn-primary' %>
     <% end %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -42,45 +42,48 @@
       <hr/>
       <div>
         <div class="card">
-          <!-- Check if user has pending friends or being requested by someone -->
-          <% if @user.pending_friends.present? %>
-            <h5 class="p-3 text-warning"> Waiting for replies: </h5>
-            <% @user.friendships.each do |friendship| %>
-              <div class="card-body pt-1 pb-1">
-                <% friend = User.find(friendship.friend_id) %>
-                <% if friendship.status === "pending" %>
-                  <span> <i class="far fa-user mr-3"></i> <%= friend.name %></span>
-                  <hr/>   
-                <% end %>
-              </div>
+          <!-- only you can see your own pending and accepting requests -->
+          <% if current_user == @user %>
+            <!-- Check if user has pending friends or being requested by someone -->
+            <% if @user.pending_friends.present? %>
+              <h5 class="p-3 text-warning"> Waiting for replies: </h5>
+              <% @user.friendships.each do |friendship| %>
+                <div class="card-body pt-1 pb-1">
+                  <% friend = User.find(friendship.friend_id) %>
+                  <% if friendship.status === "pending" %>
+                    <span> <i class="far fa-user mr-3"></i> <%= friend.name %></span>
+                    <hr/>   
+                  <% end %>
+                </div>
+              <% end %>
             <% end %>
-          <% end %>
-          <% if @user.requested_friends.present?  %>
-            <h5 class="p-3 text-warning"> Waiting for accept: </h5>
-            <% @user.friendships.each do |friendship| %>
-              <div class="card-body pt-1 pb-1">
-                <% friend = User.find(friendship.friend_id) %>
-                <% if friendship.status === "requested" %>
-                  <div class='row'>
-                    <div class='col-md-6'>
-                      <p>Name: 
-                        <%= link_to user_path(friendship.friend.id) do %> 
-                          <span class="text-dark"> 
-                            <%= friendship.friend.name %>
-                          </span>
-                        <%end%>
-                      </p>
+            <% if @user.requested_friends.present?  %>
+              <h5 class="p-3 text-warning"> Waiting for accept: </h5>
+              <% @user.friendships.each do |friendship| %>
+                <div class="card-body pt-1 pb-1">
+                  <% friend = User.find(friendship.friend_id) %>
+                  <% if friendship.status === "requested" %>
+                    <div class='row'>
+                      <div class='col-md-6'>
+                        <p>Name: 
+                          <%= link_to user_path(friendship.friend.id) do %> 
+                            <span class="text-dark"> 
+                              <%= friendship.friend.name %>
+                            </span>
+                          <%end%>
+                        </p>
+                      </div>
+                      <div class='col-md-6'>
+                        <% if @user === current_user %>
+                          <%= link_to "Accept", user_accept_request_path(user_id: current_user, friend_id: friendship.friend.id), class: 'btn btn-sm btn-success' %>
+                          <%= link_to "Block", user_block_request_path(user_id: current_user, block_id: friendship.friend.id), class: 'btn btn-sm btn-danger' %>
+                        <% end %>
+                      </div>
                     </div>
-                    <div class='col-md-6'>
-                      <% if @user === current_user %>
-                        <%= link_to "Accept", user_accept_request_path(user_id: current_user, friend_id: friendship.friend.id), class: 'btn btn-sm btn-success' %>
-                        <%= link_to "Block", user_block_request_path(user_id: current_user, block_id: friendship.friend.id), class: 'btn btn-sm btn-danger' %>
-                      <% end %>
-                    </div>
-                  </div>
-                  <hr/>
-                <% end %>
-              </div>
+                    <hr/>
+                  <% end %>
+                </div>
+              <% end %>
             <% end %>
           <% end %>
           <!-- have to separate the two conditions because the user might have a friend list and pending friends at the same time -->

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,16 @@
-<div class="container p-4">
-  <h2><%= @user.name %></h2>
+<div class="container">
+  <div class="row">
+    <div class="col-sm-6">
+      <h2><%= @user.name %></h2>      
+    </div>
+    <% if @user == current_user %>
+      <div class="col-sm-6">
+        <%= link_to new_prayer_path, class: 'btn btn-outline-primary float-right' do %>
+          <span><i class="fas fa-plus"></i> Add prayer </span>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
   <div class="row">
     <div class="col-sm-4 p-3">
       <div class="row">
@@ -86,15 +97,14 @@
           <% end %>
         <% end %>
       <% end %>
-      <h4 class="theme-color text-center"> Your prayer requests 
-        <%= fa_icon('pray 1x', type: :solid, class: 'theme-color icon-font-size') %>
-      </h4>
-      <table class="table table-striped">
+      <table class="table table-striped table-hover">
         <thead>
-          <tr class="bg-primary">
-            <th scope="col">#</th>
-            <th scope="col">Prayer</th>
-            <th scope="col">Posted on</th>
+          <tr class="bg-white">
+            <th colspan='3'>
+              <h4 class="text-left"> Your prayer requests 
+                <%= fa_icon('pray 1x', type: :solid, class: 'icon-font-size') %>
+              </h4>
+            </th>
             <% if @user === current_user %>
               <th scope="col"></th>
               <th scope="col"></th>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -133,7 +133,7 @@
           </tr>
         </thead>
         <tbody>
-          <% @user.prayers.order(created_at: :desc).each_with_index do |prayer, index| %>
+          <% @prayers.order(created_at: :desc).each_with_index do |prayer, index| %>
             <tr>
               <th scope="row"><%= index + 1 %></th>
               <!-- link to prayer SHOW page next time -->
@@ -143,8 +143,7 @@
               <% if @user === current_user %>
                 <td><%= link_to 'Edit', edit_prayer_path(prayer.id), class: 'btn btn-sm btn-success'%></td>
                 <td><%= link_to 'X', prayer_path(prayer.id), method: :delete, data: {confirm: "Are you sure you want to delete this prayer?"}, class: 'btn btn-sm btn-danger'%></td>
-              <% end %>
-              
+              <% end %>     
             </tr>
           <% end %>
         </tbody>

--- a/db/migrate/20200816115603_add_private_to_prayers.rb
+++ b/db/migrate/20200816115603_add_private_to_prayers.rb
@@ -1,5 +1,5 @@
 class AddPrivateToPrayers < ActiveRecord::Migration[6.0]
   def change
-    add_column :prayers, :private, :boolean
+    add_column :prayers, :private, :boolean, default: false
   end
 end

--- a/db/migrate/20200816115603_add_private_to_prayers.rb
+++ b/db/migrate/20200816115603_add_private_to_prayers.rb
@@ -1,0 +1,5 @@
+class AddPrivateToPrayers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :prayers, :private, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 2020_08_16_115603) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
     t.integer "status", default: 0
-    t.boolean "private"
+    t.boolean "private", default: false
     t.index ["status"], name: "index_prayers_on_status"
     t.index ["user_id"], name: "index_prayers_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_05_015354) do
+ActiveRecord::Schema.define(version: 2020_08_16_115603) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,9 @@ ActiveRecord::Schema.define(version: 2020_07_05_015354) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
+    t.integer "status", default: 0
+    t.boolean "private"
+    t.index ["status"], name: "index_prayers_on_status"
     t.index ["user_id"], name: "index_prayers_on_user_id"
   end
 


### PR DESCRIPTION
# Pull Request Description 

Task(s) you did:
Main task is to make private prayer request.

If a prayer is private, you shouldn't be able to see it in your user's profile page and on the home page. Also, it would randomly generate the prayer in the 'Pray for someone' button.

Minor:
- Only user of their profile can see the pending friend requests.


How did you test it? : 
Tested with 3 accounts A, B and C
- If A is friends with B, B should be able to see A's private prayer
- If A is not friends with C, then C shouldn't be able to see A's private prayer
- A should be able to see all his prayers

Tested also that private prayer doesn't show up in prayer homepage and when click 'Pray for single request' or 'pray for multiple requests'



Remarks:
- Can think about an 'Only me' option for the prayer.